### PR TITLE
[WIP] fixes issue #577. other goal: build velum image with one dockerfile

### DIFF
--- a/caasp-devenv
+++ b/caasp-devenv
@@ -30,7 +30,8 @@ ACTION=
 MASTERS=${CAASP_NUM_MASTERS:-1}
 WORKERS=${CAASP_NUM_WORKERS:-2}
 IMAGE=${CAASP_IMAGE:-channel://devel}
-VELUM_IMAGE=${CAASP_VELUM_IMAGE:-channel://devel}
+VELUM_IMAGE=${CAASP_VELUM_IMAGE:-registry.suse.de/devel/casp/head/controllernode/images_container_base/sles12/velum-development:0.0}
+CACHE_VELUM=${CAASP_CACHE_VELUM:-false}
 VANILLA=${CAASP_VANILLA:-}
 DISABLE_MELTDOWN_SPECTRE=${CAASP_DISABLE_MELTDOWN_SPECTRE:-}
 PROXY=${CAASP_HTTP_PROXY:-}
@@ -79,7 +80,8 @@ Usage:
     -u|--update-deployment           Update Terraform deployment (Default: false)
     -d|--destroy                     Run the CaaSP KVM Destroy Step
     -i|--image                       Image to use (Default: CAASP_IMAGE)
-    --velum-image                    Container image to use for Velum build (Default: channel://devel)
+    --velum-image                    Container image to use for Velum build (Default: registry.suse.de)
+    --cache-velum                    Use existing local velum:development image (Default: false)
     --vanilla                        Do not inject devenv code, use vanilla caasp (Default: false)
     --disable-meltdown-spectre-fixes Disable meltdown and spectre fixes (Default: false)
     --enable-tiller                  Enable Helm Tiller
@@ -186,6 +188,10 @@ while [[ $# > 0 ]] ; do
       VELUM_IMAGE="$2"
       shift
       ;;
+    --cache-velum)
+      CACHE_VELUM="$2"
+      shift
+      ;;
     --vanilla)
       VANILLA="true"
       ;;
@@ -242,6 +248,7 @@ CAASP_KVM_ARGS="-m $MASTERS -w $WORKERS --image $IMAGE"
 [ -n "$LOCATION"    ] && CAASP_KVM_ARGS="$CAASP_KVM_ARGS --location $LOCATION"
 [ -n "$VANILLA"     ] && CAASP_KVM_ARGS="$CAASP_KVM_ARGS --vanilla"
 [ -n "$VELUM_IMAGE" ] && CAASP_KVM_ARGS="$CAASP_KVM_ARGS --velum-image $VELUM_IMAGE"
+[ -n "$CACHE_VELUM" ] && CAASP_KVM_ARGS="$CAASP_KVM_ARGS --cache-velum $CACHE_VELUM"
 [ -n "$DISABLE_MELTDOWN_SPECTRE" ] && CAASP_KVM_ARGS="$CAASP_KVM_ARGS --disable-meltdown-spectre-fixes"
 [ -n "$EXTRA_REPO"  ] && CAASP_KVM_ARGS="$CAASP_KVM_ARGS --extra-repo $EXTRA_REPO"
 

--- a/caasp-devenv
+++ b/caasp-devenv
@@ -30,6 +30,7 @@ ACTION=
 MASTERS=${CAASP_NUM_MASTERS:-1}
 WORKERS=${CAASP_NUM_WORKERS:-2}
 IMAGE=${CAASP_IMAGE:-channel://devel}
+VELUM_IMAGE=${CAASP_VELUM_IMAGE:-channel://devel}
 VANILLA=${CAASP_VANILLA:-}
 DISABLE_MELTDOWN_SPECTRE=${CAASP_DISABLE_MELTDOWN_SPECTRE:-}
 PROXY=${CAASP_HTTP_PROXY:-}
@@ -78,6 +79,7 @@ Usage:
     -u|--update-deployment           Update Terraform deployment (Default: false)
     -d|--destroy                     Run the CaaSP KVM Destroy Step
     -i|--image                       Image to use (Default: CAASP_IMAGE)
+    --velum-image                    Container image to use for Velum build (Default: channel://devel)
     --vanilla                        Do not inject devenv code, use vanilla caasp (Default: false)
     --disable-meltdown-spectre-fixes Disable meltdown and spectre fixes (Default: false)
     --enable-tiller                  Enable Helm Tiller
@@ -180,6 +182,10 @@ while [[ $# > 0 ]] ; do
       IMAGE="$2"
       shift
       ;;
+    --velum-image)
+      VELUM_IMAGE="$2"
+      shift
+      ;;
     --vanilla)
       VANILLA="true"
       ;;
@@ -235,6 +241,7 @@ CAASP_KVM_ARGS="-m $MASTERS -w $WORKERS --image $IMAGE"
 [ -n "$PROXY"       ] && CAASP_KVM_ARGS="$CAASP_KVM_ARGS --proxy $PROXY"
 [ -n "$LOCATION"    ] && CAASP_KVM_ARGS="$CAASP_KVM_ARGS --location $LOCATION"
 [ -n "$VANILLA"     ] && CAASP_KVM_ARGS="$CAASP_KVM_ARGS --vanilla"
+[ -n "$VELUM_IMAGE" ] && CAASP_KVM_ARGS="$CAASP_KVM_ARGS --velum-image $VELUM_IMAGE"
 [ -n "$DISABLE_MELTDOWN_SPECTRE" ] && CAASP_KVM_ARGS="$CAASP_KVM_ARGS --disable-meltdown-spectre-fixes"
 [ -n "$EXTRA_REPO"  ] && CAASP_KVM_ARGS="$CAASP_KVM_ARGS --extra-repo $EXTRA_REPO"
 
@@ -242,7 +249,7 @@ export ENVIRONMENT="$DIR/caasp-kvm/environment.json"
 
 # Core methods
 setup() {
-  log "Installing CaaSP Development Environment Requiemnts"
+  log "Installing CaaSP Development Environment Requirements"
   sudo zypper in --no-confirm --auto-agree-with-licenses $EARLY_DIST_PACKAGES
 
   local dist=$(lsb-release -sd | tr -d '"' | tr " " "_")

--- a/caasp-kvm/caasp-kvm
+++ b/caasp-kvm/caasp-kvm
@@ -17,7 +17,8 @@ DIST=${CAASP_DIST:-caasp}
 MASTERS=${CAASP_NUM_MASTERS:-1}
 WORKERS=${CAASP_NUM_WORKERS:-2}
 IMAGE=${CAASP_IMAGE:-channel://devel}
-VELUM_IMAGE=${CAASP_VELUM_IMAGE:-channel://devel}
+VELUM_IMAGE=${CAASP_VELUM_IMAGE:-registry.suse.de/devel/casp/head/controllernode/images_container_base/sles12/velum-development:0.0}
+CACHE_VELUM=${CAASP_CACHE_VELUM:-false}
 VANILLA=${CAASP_VANILLA:-}
 DISABLE_MELTDOWN_SPECTRE=${CAASP_DISABLE_MELTDOWN_SPECTRE:-}
 PROXY=${CAASP_HTTP_PROXY:-}
@@ -149,6 +150,10 @@ while [[ $# > 0 ]] ; do
       ;;
     --velum-image)
       VELUM_IMAGE="$2"
+      shift
+      ;;
+    --cache-velum)
+      CACHE_VELUM="$2"
       shift
       ;;
     --vanilla)
@@ -339,8 +344,8 @@ build() {
 
   if [ -n "$CAASP_VELUM_DIR" -a "$VANILLA" != "true" ] ; then
     log "Rebuilding Velum Development Docker Image"
-    if [[ "$VELUM_IMAGE" =~ [Cc]ache ]]; then
-      # Do not rebuild Docker image at all
+    if [[ "$CACHE_VELUM" == 'true' ]]; then
+      # Do not rebuild Docker image
       $DIR/tools/build-velum-image "$CAASP_VELUM_DIR" "${VELUM_IMAGE}" "${PROXY}" -c
     else
       $DIR/tools/build-velum-image "$CAASP_VELUM_DIR" "${VELUM_IMAGE}" "${PROXY}"

--- a/caasp-kvm/caasp-kvm
+++ b/caasp-kvm/caasp-kvm
@@ -339,7 +339,12 @@ build() {
 
   if [ -n "$CAASP_VELUM_DIR" -a "$VANILLA" != "true" ] ; then
     log "Rebuilding Velum Development Docker Image"
-    $DIR/tools/build-velum-image "$CAASP_VELUM_DIR" "${VELUM_IMAGE}" "${PROXY}"
+    if [[ "$VELUM_IMAGE" =~ [Cc]ache ]]; then
+      # Do not rebuild Docker image at all
+      $DIR/tools/build-velum-image "$CAASP_VELUM_DIR" "${VELUM_IMAGE}" "${PROXY}" -c
+    else
+      $DIR/tools/build-velum-image "$CAASP_VELUM_DIR" "${VELUM_IMAGE}" "${PROXY}"
+    fi
 
     log "Creating Velum Directories"
     mkdir -p "$CAASP_VELUM_DIR/tmp" "$CAASP_VELUM_DIR/log" "$CAASP_VELUM_DIR/vendor/bundle"

--- a/caasp-kvm/tools/build-velum-image
+++ b/caasp-kvm/tools/build-velum-image
@@ -19,12 +19,6 @@ log()        { (>&2 echo ">>> [build-velum-image] $@") ; }
 warn()       { log "WARNING: $@" ; }
 error()      { log "ERROR: $@" ; exit 1 ; }
 
-do_commit() {
-  docker logs -f "$1"
-  docker commit "$1" $IMAGE_DIST/velum:development_wip
-  docker rm "$1"
-}
-
 # Helper function to get the velum-development reference
 # most logic is to dynamically get to the newest tag
 # can be dropped when registry.opensuse.org has a "latest" tag
@@ -49,6 +43,23 @@ kubic_velum_development_reference() {
   echo $BASE_URL/$RELATIVE_PATH/$IMAGE_DIST/velum-development:${FIRST_TAG}
 }
 
+
+build_image() {
+  pushd $VELUM_DIR > /dev/null
+  log "Building velum image from Dockerfile located at $VELUM_DIR"
+  docker build -t velum:development_local .
+  popd > /dev/null
+}
+
+
+save_image() {
+  rm -f "$VELUM_DEVEL_IMAGE"
+  docker save $IMAGE_DIST/velum:development -o "$VELUM_DEVEL_IMAGE"
+  chmod 644 "$VELUM_DEVEL_IMAGE"
+  log "Velum image saved to $VELUM_DEVEL_IMAGE"
+}
+
+
 # get distribution
 if [[ $(basename $IMAGE) =~ [Kk]ubic ]]; then
   IMAGE_DIST=kubic
@@ -66,125 +77,6 @@ else
   IMAGE_REFERENCE=$IMAGE
 fi
 
-
-# docker load of the velum-development image tarball
-load_velum_development_image() {
-  log "Loading velum development image"
-  docker rmi $IMAGE_DIST/velum-development:0.0 || : 2> /dev/null
-  docker rmi $IMAGE_DIST/velum:development || : 2> /dev/null
-  docker load -i "${IMAGE:7}"
-}
-
-# docker pull of the velum-development image
-pull_velum_development_image() {
-  log "Pulling velum development image"
-  docker pull $IMAGE_REFERENCE
-}
-
-build_fresh_image() {
-  log "Building velum image with all the required gems"
-  # Reuse the gems already vendored into the devel image if possible.
-  # This will pull only the development gems and the ones changed on master.
-  # This greatly reduces the creation time of the image
-  local CONTAINER_BUILD=`docker run -v $VELUM_DIR:/srv/velum-latest -d $IMAGE_REFERENCE \
-                    bash -c "
-                      cd /srv/velum-latest && \
-                      mkdir -p /var/lib/velum && \
-                      gem install --no-ri --no-rdoc bundler -n /usr/bin && \
-                      bundle.${RUBY_VERSION} config --local frozen 0 && \
-                      bundle.${RUBY_VERSION} config --local build.nokogiri --use-system-libraries && \
-                      bundle.${RUBY_VERSION} install --deployment --binstubs=/usr/local/bin --path=/var/lib/velum && \
-                      cp Gemfile.lock /var/lib/velum/ && \
-                      wget -q https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 -P /opt && \
-                      tar -xjf /opt/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C /opt && \
-                      mv /opt/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin && \
-                      rm -rf /opt/phantomjs-2.1.1-linux-x86_64"`
-  do_commit "$CONTAINER_BUILD"
-}
-
-patch_schema() {
-  # The only reason for the existence of this patch is a very nasty hack that needs to be removed
-  # as soon as possible.
-  #
-  # It is very closely tied to this patch existence:
-  # https://github.com/kubic-project/velum/blob/master/packaging/suse/patches/1_set_default_salt_events_alter_time_column_value.rpm.patch
-  #
-  # The problem
-  #
-  # We are patching the production schema. But we are mounting the development source code from the
-  # host. So, when we run `bin/init`, the schema that gets loaded is the one on the developers machine,
-  # that of course doesn't contain this patch. Without this patch, the salt-master fails to register
-  # events on the database, due to a missing default value on `alter_time` column.
-  #
-  # The schema salt requires is: https://docs.saltstack.com/en/latest/ref/returners/all/salt.returners.mysql.html
-  #
-  # CREATE TABLE `salt_events` (
-  # `id` BIGINT NOT NULL AUTO_INCREMENT,
-  # `tag` varchar(255) NOT NULL,
-  # `data` mediumtext NOT NULL,
-  # `alter_time` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  # `master_id` varchar(255) NOT NULL,
-  # PRIMARY KEY (`id`),
-  # KEY `tag` (`tag`)
-  # ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-  #
-  # We are handling this table as if it was another Rails managed table, so it's in the Rails schema.
-  #
-  # So far, so good. The main problem is that Rails 4 does not support functions as default values.
-  # This means that if we patch the development environment, after running a migration, or running
-  # `db:schema:dump`, Rails won't recover this default value, and the schema it writes will be wrong.
-  # The good news is that this is fixed in Rails 5.
-  #
-  # Without this patch, salt-master refuses to create new salt events, with the error:
-  #
-  # [ERROR ] Could not store events - returner 'mysql.event_return' raised exception:
-  #          (1364, "Field 'alter_time' doesn't have a default value")
-  #
-  # The solution
-  #
-  # Use the production container that has the production schema (patched). Copy it on `/var/lib/velum`,
-  # since we will mount our source code in `/srv/velum` and the original `/srv/velum/db/schema.rb`
-  # won't be available, and then infect `bin/init` script to run `db:schema:load` with the
-  # `/var/lib/velum/schema.rb` schema if it exists; otherwise run a `db:load` without specifying the
-  # schema (that will take `/srv/velum/db/schema.rb` by default), so we don't break the default
-  # behavior.
-  #
-  # Commit the $IMAGE_DIST/velum:development image again, as if nothing ever happened.
-
-  log "Patching schema of velum image"
-  local CONTAINER_BUILD=`docker run -d $IMAGE_DIST/velum:development_wip cp /srv/velum/db/schema.rb /var/lib/velum`
-  do_commit "$CONTAINER_BUILD"
-}
-
-# Set special environment variables needed to find the gems we vendored
-# into a different location
-# Creates also the sles/velum:latest image
-set_env_variables() {
-  log "Adding special env variables into the final image"
-
-  local TMP_DIR=`mktemp -d`
-  cat << EOF > $TMP_DIR/Dockerfile
-FROM $IMAGE_DIST/velum:development_wip
-ENV BUNDLE_GEMFILE /srv/velum/Gemfile
-ENV BUNDLE_FROZEN 1
-ENV BUNDLE_PATH /var/lib/velum
-ENV BUNDLE_DISABLE_SHARED_GEMS 1
-EOF
-  docker build -t $IMAGE_DIST/velum:development "$TMP_DIR"
-
-  # this image is now useless - it can be untagged
-  docker rmi $IMAGE_DIST/velum:development_wip
-
-  rm -rf "$TMP_DIR"
-}
-
-save_image() {
-  rm -f "$VELUM_DEVEL_IMAGE"
-  docker save $IMAGE_DIST/velum:development -o "$VELUM_DEVEL_IMAGE"
-  chmod 644 "$VELUM_DEVEL_IMAGE"
-  log "Velum image saved to $VELUM_DEVEL_IMAGE"
-}
-
 # Parse args
 USE_CACHE=
 while getopts ":c" opt; do
@@ -201,18 +93,10 @@ shift $(expr $OPTIND - 1 )
 
 [ -d "$VELUM_DIR" ] || error "Velum directory $VELUM_DIR does not exist"
 [ -n "$USE_CACHE" ] && [ -f "$VELUM_DEVEL_IMAGE" ] && {
-  log "Using prebuilt image"
+  log "Using prebuilt image as requested, skipping build step."
   exit 0
 }
 
-if [[ $IMAGE == file://* ]]; then
-  load_velum_development_image
-else
-  pull_velum_development_image
-fi
-build_fresh_image
-
-# FIXME: remove this once we upgrade to Rails 5
-patch_schema
-set_env_variables
+build_image
 save_image
+


### PR DESCRIPTION
* Change velum image build to use only upstream utilities (read: not behind VPN) and local code changes 
* Move actual Dockerfile to live with velum code (https://github.com/stefsuse/velum/pull/1)
* Allow caasp-kvm script to propagate "cache" flag, to skip local builds entirely
* small typo - "Requirements"
* Address issue #577 by locking to a known good version of Bundler

The end result of the docker build, velum-development.tar, should be the same but there are some important differences in how it gets built. 

Old way: 
pull image from registry.suse.de (defined by kiwi spec in H:Cn)
run a container from this image, mounts the velum source directory as a volume, run bundler build, then commit these changes to a WIP image
run a container from updated image to update schema file and commit
run a container from updated image to add environment variables and commit to final development image
save image tar to disk

New way: 
if not using cache, move to Velum development directory and run docker build. The Dockerfile copies the required code into the container instead of relying on mounts.
save image tar to disk
if using cache, log message and exit